### PR TITLE
Slack incoming webhooks' use URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,12 @@ Edit `/home/dokku/dokkurc` or `/etc/slack`
 
 ```sh
 export SLACK_NOTIFY=1
-export SLACK_DOMAIN=<domain>
-export SLACK_TOKEN=<token>
+export SLACK_URL=<url>
 export SLACK_USERNAME='Dokku'
 export SLACK_CHANNEL=dokku #default_channel
 ```
 
-The domain is the subdomain part of the URL use use to get to the Slack webapp. For example for `http://ribot.slack.com/` it's `ribot`.
+The URL is found in the configuration of your incoming webhook.
 
 ### Enabling or disabling for a specific app
 

--- a/slack-notify
+++ b/slack-notify
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-# Check we have a slack domain
-if [ ! -n "$SLACK_DOMAIN" ]; then
-  echo 'Please specify the domain'; exit 1
-fi
-
-# Check we have a slack token
-if [ ! -n "$SLACK_TOKEN" ]; then
+# Check we have a slack url
+if [ ! -n "$SLACK_URL" ]; then
   echo 'Please specify a token'; exit 1
 fi
 
@@ -28,7 +23,7 @@ fi
 JSON="{\"channel\": \"#$SLACK_CHANNEL\", \"text\": \"$MESSAGE\", \"username\": \"$SLACK_USERNAME\"}"
 
 # Send the message
-RESULT=`curl -s -d "payload=$JSON" "https://$SLACK_DOMAIN.slack.com/services/hooks/incoming-webhook?token=$SLACK_TOKEN" -w "%{http_code}"`
+RESULT=`curl -s -d "payload=$JSON" "${SLACK_URL}" -w "%{http_code}"`
 echo $RESULT
 
 # TODO: Add error handling


### PR DESCRIPTION
Incoming webhooks' have changed from using a standard URL only varying
the token and domain, to a unique URL.
