### PR TITLE
Allow webhook to be configured globally

### DIFF
--- a/commands
+++ b/commands
@@ -2,33 +2,52 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$(dirname $0)/../common/functions"
 
+is_webhook() {
+  echo "$1" | grep -E '^http[s]?://'
+}
+
+get_slack_root() {
+  if [[ -z $(is_webhook "$1") ]]; then
+    verify_app_name "$1"
+    APP="$1"
+    echo "$DOKKU_ROOT/$APP"
+  else
+    echo "$DOKKU_ROOT"
+  fi
+}
+
+get_webhook() {
+  if [[ -n $1 && -n $2 ]]; then
+    echo "$2"
+  else
+    echo "$1"
+  fi
+}
+
 case "$1" in
   slack:set)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
-    echo "$3" > "$DOKKU_ROOT/$APP/SLACK_URL"
+    SLACK_ROOT=$(get_slack_root "$2")
+    WEBHOOK=$(get_webhook "$2" "$3")
+    [[ -z $WEBHOOK ]] && echo "Please specify at least a webhook URL" && exit 1
+    [[ -z $(is_webhook "$WEBHOOK") ]] && echo "Webhook has to be an URL" && exit 1
+    echo "$WEBHOOK" > "$SLACK_ROOT/SLACK_URL"
     ;;
 
   slack:clear)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
-    rm "$DOKKU_ROOT/$APP/SLACK_URL"
+    SLACK_ROOT=$(get_slack_root "$2")
+    rm "$SLACK_ROOT/SLACK_URL"
     ;;
 
   slack:get)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
-    cat "$DOKKU_ROOT/$APP/SLACK_URL"
+    SLACK_ROOT=$(get_slack_root "$2")
+    cat "$SLACK_ROOT/SLACK_URL"
     ;;
 
   help)
     cat && cat<<EOF
-    slack:set <app> <webhook_url>                   Set Slack WebHook URL
-    slack:clear <app>                               Clears Slack WebHook URL
-    slack:get <app>                                 Display Slack WebHook URL
+    slack:set [app] <webhook_url>                   Set Slack WebHook URL
+    slack:clear [app]                               Clears Slack WebHook URL
+    slack:get [app]                                 Display Slack WebHook URL
 EOF
     ;;
 

--- a/post-deploy
+++ b/post-deploy
@@ -5,10 +5,10 @@ APP="$1"
 IMAGE="$2"
 HOSTNAME=$(hostname -f)
 
-if [ -f $DOKKU_ROOT/$APP/SLACK_URL ]; then
+if [[ -f "$DOKKU_ROOT/$APP/SLACK_URL" || -f "$DOKKU_ROOT/SLACK_URL" ]]; then
   echo "-----> Notifying Slack ..."
   URL=$(dokku url $APP)
-  SLACK_URL=$(cat $DOKKU_ROOT/$APP/SLACK_URL)
+  SLACK_URL=$(cat "$DOKKU_ROOT/$APP/SLACK_URL" 2> /dev/null || cat "$DOKKU_ROOT/SLACK_URL" 2> /dev/null)
   SLACK_JSON="{ \
     \"attachments\": [{ \
       \"text\": \"Deployed $APP to $HOSTNAME via $URL\", \


### PR DESCRIPTION
The "app" part of the existing commands is now optional and allows the
webhook to be enabled globally (for all apps).
When a global webhook is enabled and a specific one for an app is also
enabled, the notification will be send to the specific one.